### PR TITLE
fixes typo in Timeseries schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -547,7 +547,7 @@ components:
           format: float
           example: 15
           description: "Abstand der Messwerte in Minuten."
-        currrentMeasurement:
+        currentMeasurement:
           $ref: "#/components/schemas/CurrentMeasurement"
         gaugeZero:
           type: object


### PR DESCRIPTION
I stumbled over this issue while using your API.

```bash
curl -X 'GET' \
  'https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations/593647aa-9fea-43ec-a7d6-6476a76ae868/W.json?includeCurrentMeasurement=true&includeCharacteristicValues=false' \
  -H 'accept: application/json'
```

Returns the following:
```json
{
  "shortname": "W",
  "longname": "WASSERSTAND ROHDATEN",
  "unit": "cm",
  "equidistance": 15,
  "currentMeasurement": {
    "timestamp": "2023-03-13T21:45:00+01:00",
    "value": 387,
    "stateMnwMhw": "normal",
    "stateNswHsw": "unknown"
  },
  "gaugeZero": {
    "unit": "m. ü. NHN",
    "value": 42.713,
    "validFrom": "2019-11-01"
  }
}
```

Since there is the typo "currrentMeasurement" in the Timeseries schema, the generated openapi client was unable to return the value.

I used the generated openapi generator: `typescript-fetch`